### PR TITLE
Viser "<" på elementer som har tomme intervaller

### DIFF
--- a/src/Kodetre/Kodeliste/Kodelisteelement.js
+++ b/src/Kodetre/Kodeliste/Kodelisteelement.js
@@ -13,6 +13,7 @@ function hack(symbol, intervall) {
 function getSecondary(meta) {
   let { intervall } = meta;
   if (!intervall) return;
+  if (!(intervall.minTekst || intervall.maxTekst)) return;
   if (!Array.isArray(intervall)) intervall = [intervall];
   const items = intervall.map(i => {
     if (!i.minTekst) return hack("<", i.maxTekst);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/281359/54320327-e51d1e80-45ec-11e9-8ba9-e81b8efcb444.png)
